### PR TITLE
Fix compilation with nvcc 10.1.

### DIFF
--- a/common/src/logger.cpp
+++ b/common/src/logger.cpp
@@ -1,8 +1,12 @@
 #include<logger.hpp>
 
-using namespace livai::tts::common;
+namespace livai {
 
-// change it to json file later.. 
+namespace tts {
+
+namespace common {
+
+// change it to json file later..
 std::ostream out(std::cout.rdbuf());
 
 template<>
@@ -16,4 +20,10 @@ void log<std::vector<size_t>>(const std::string& name, const std::vector<size_t>
     }
 
     out<<name<<" : "<<valString<<"\n";
+}
+
+}
+
+}
+
 }


### PR DESCRIPTION
This PR fixes compilation with nvcc 10.1
(it looks nvcc 10.1 does not like `using namespace`)

```
$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Sun_Jul_28_19:07:16_PDT_2019
Cuda compilation tools, release 10.1, V10.1.243

$ nvcc -arch=sm_70 -std=c++11 -O2  -Iwaveglow/header/ -Icommon/header -Isys/header -o common/obj/logger.o -c common/src/logger.cpp -D DEBUG
common/src/logger.cpp:9:6: error: explicit specialization of ‘template<class T> void livai::tts::common::log(const string&, const T&)’ outside its namespace must use a nested-name-specifier [-fpermissive]
 void log<std::vector<size_t>>(const std::string& name, const std::vector<size_t>& obj)
      ^~~~~~~~~~~~~~~~~~~~~~~~
```